### PR TITLE
Add PrintSegments() to print hop fields of path segments

### DIFF
--- a/go/lib/sciond/BUILD.bazel
+++ b/go/lib/sciond/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//go/lib/infra/disp:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/sock/reliable:go_default_library",
+        "//go/lib/spath:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_patrickmn_go_cache//:go_default_library",


### PR DESCRIPTION
Allow [metricapp][metricapp] to print hop fields containing in path segments. Details of forwarding path and path segments are explained in SCION book §15.1.3.

Reply from [`pathMgr.Query()`][query] already contains hop fields that are serialized in [`path.Entry.Path.FwdPath`][fwdpath], so [`PrintSegments()`][print-segments] just deserializes them and prints to stdout. The serialization is done in [`buildSCIONDReplyEntries()`][build-reply] and [`WriteTo()`][write-to].

Outputs when running metricapp under default SCION topology:
```
user@host:~/go/src/github.com/netsec-ethz/scion-apps$ $GOPATH/bin/metricapp -local 1-ff00:0:132,[127.0.0.1]:0 -remote 2-ff00:0:221,[127.0.0.1]:9000
Available paths:
[ 0] 5 Hops: [1-ff00:0:132 2>4078 1-ff00:0:131 4079>1001 1-ff00:0:130 1005>1 1-ff00:0:120 3>502 2-ff00:0:220 500>2 2-ff00:0:221] Mtu: 1400
[Segment 0]
HopField 0: ConsIngress: 2 ConsEgress: 0 ExpTime: 63 Xover: false VerifyOnly: false Mac: 8f4939
HopField 1: ConsIngress: 4079 ConsEgress: 4078 ExpTime: 63 Xover: false VerifyOnly: false Mac: bd53fe
HopField 2: ConsIngress: 0 ConsEgress: 1001 ExpTime: 63 Xover: true VerifyOnly: false Mac: 38ad07
[Segment 1]
HopField 0: ConsIngress: 1005 ConsEgress: 0 ExpTime: 63 Xover: true VerifyOnly: false Mac: 45c613
HopField 1: ConsIngress: 3 ConsEgress: 1 ExpTime: 63 Xover: false VerifyOnly: false Mac: 6d0e32
HopField 2: ConsIngress: 0 ConsEgress: 502 ExpTime: 63 Xover: true VerifyOnly: false Mac: 87a6b0
[Segment 2]
HopField 0: ConsIngress: 0 ConsEgress: 500 ExpTime: 63 Xover: true VerifyOnly: false Mac: 59e7a8
HopField 1: ConsIngress: 2 ConsEgress: 0 ExpTime: 63 Xover: false VerifyOnly: false Mac: f01e93
[ 1] 5 Hops: [1-ff00:0:132 2>4078 1-ff00:0:131 4079>1001 1-ff00:0:130 1005>1 1-ff00:0:120 2>501 2-ff00:0:220 500>2 2-ff00:0:221] Mtu: 1350
[Segment 0]
HopField 0: ConsIngress: 2 ConsEgress: 0 ExpTime: 63 Xover: false VerifyOnly: false Mac: 8f4939
HopField 1: ConsIngress: 4079 ConsEgress: 4078 ExpTime: 63 Xover: false VerifyOnly: false Mac: bd53fe
HopField 2: ConsIngress: 0 ConsEgress: 1001 ExpTime: 63 Xover: true VerifyOnly: false Mac: 38ad07
[Segment 1]
HopField 0: ConsIngress: 1005 ConsEgress: 0 ExpTime: 63 Xover: true VerifyOnly: false Mac: e63dc2
HopField 1: ConsIngress: 2 ConsEgress: 1 ExpTime: 63 Xover: false VerifyOnly: false Mac: 08f52f
HopField 2: ConsIngress: 0 ConsEgress: 501 ExpTime: 63 Xover: true VerifyOnly: false Mac: 9047d6
[Segment 2]
HopField 0: ConsIngress: 0 ConsEgress: 500 ExpTime: 63 Xover: true VerifyOnly: false Mac: 59e7a8
HopField 1: ConsIngress: 2 ConsEgress: 0 ExpTime: 63 Xover: false VerifyOnly: false Mac: f01e93
[ 2] 6 Hops: [1-ff00:0:132 2>4078 1-ff00:0:131 4079>1001 1-ff00:0:130 1004>2 1-ff00:0:110 1>6 1-ff00:0:120 3>502 2-ff00:0:220 500>2 2-ff00:0:221] Mtu: 1400
[Segment 0]
HopField 0: ConsIngress: 2 ConsEgress: 0 ExpTime: 63 Xover: false VerifyOnly: false Mac: 8f4939
HopField 1: ConsIngress: 4079 ConsEgress: 4078 ExpTime: 63 Xover: false VerifyOnly: false Mac: bd53fe
HopField 2: ConsIngress: 0 ConsEgress: 1001 ExpTime: 63 Xover: true VerifyOnly: false Mac: 38ad07
[Segment 1]
HopField 0: ConsIngress: 1004 ConsEgress: 0 ExpTime: 63 Xover: true VerifyOnly: false Mac: 002664
HopField 1: ConsIngress: 1 ConsEgress: 2 ExpTime: 63 Xover: false VerifyOnly: false Mac: c850e1
HopField 2: ConsIngress: 3 ConsEgress: 6 ExpTime: 63 Xover: false VerifyOnly: false Mac: 9037b1
HopField 3: ConsIngress: 0 ConsEgress: 502 ExpTime: 63 Xover: true VerifyOnly: false Mac: 87a6b0
[Segment 2]
HopField 0: ConsIngress: 0 ConsEgress: 500 ExpTime: 63 Xover: true VerifyOnly: false Mac: 59e7a8
HopField 1: ConsIngress: 2 ConsEgress: 0 ExpTime: 63 Xover: false VerifyOnly: false Mac: f01e93
[ 3] 6 Hops: [1-ff00:0:132 2>4078 1-ff00:0:131 4079>1001 1-ff00:0:130 1004>2 1-ff00:0:110 3>453 2-ff00:0:210 450>503 2-ff00:0:220 500>2 2-ff00:0:221] Mtu: 1280
[Segment 0]
HopField 0: ConsIngress: 2 ConsEgress: 0 ExpTime: 63 Xover: false VerifyOnly: false Mac: 8f4939
HopField 1: ConsIngress: 4079 ConsEgress: 4078 ExpTime: 63 Xover: false VerifyOnly: false Mac: bd53fe
HopField 2: ConsIngress: 0 ConsEgress: 1001 ExpTime: 63 Xover: true VerifyOnly: false Mac: 38ad07
[Segment 1]
HopField 0: ConsIngress: 1004 ConsEgress: 0 ExpTime: 63 Xover: true VerifyOnly: false Mac: ebc39e
HopField 1: ConsIngress: 3 ConsEgress: 2 ExpTime: 63 Xover: false VerifyOnly: false Mac: 608824
HopField 2: ConsIngress: 450 ConsEgress: 453 ExpTime: 63 Xover: false VerifyOnly: false Mac: ea52e7
HopField 3: ConsIngress: 0 ConsEgress: 503 ExpTime: 63 Xover: true VerifyOnly: false Mac: 9b8c12
[Segment 2]
HopField 0: ConsIngress: 0 ConsEgress: 500 ExpTime: 63 Xover: true VerifyOnly: false Mac: 59e7a8
HopField 1: ConsIngress: 2 ConsEgress: 0 ExpTime: 63 Xover: false VerifyOnly: false Mac: f01e93
[ 4] 6 Hops: [1-ff00:0:132 2>4078 1-ff00:0:131 4079>1001 1-ff00:0:130 1004>2 1-ff00:0:110 1>6 1-ff00:0:120 2>501 2-ff00:0:220 500>2 2-ff00:0:221] Mtu: 1350
[Segment 0]
HopField 0: ConsIngress: 2 ConsEgress: 0 ExpTime: 63 Xover: false VerifyOnly: false Mac: 8f4939
HopField 1: ConsIngress: 4079 ConsEgress: 4078 ExpTime: 63 Xover: false VerifyOnly: false Mac: bd53fe
HopField 2: ConsIngress: 0 ConsEgress: 1001 ExpTime: 63 Xover: true VerifyOnly: false Mac: 38ad07
[Segment 1]
HopField 0: ConsIngress: 1004 ConsEgress: 0 ExpTime: 63 Xover: true VerifyOnly: false Mac: 9e48ca
HopField 1: ConsIngress: 1 ConsEgress: 2 ExpTime: 63 Xover: false VerifyOnly: false Mac: 060c6a
HopField 2: ConsIngress: 2 ConsEgress: 6 ExpTime: 63 Xover: false VerifyOnly: false Mac: 8f3a5e
HopField 3: ConsIngress: 0 ConsEgress: 501 ExpTime: 63 Xover: true VerifyOnly: false Mac: 9047d6
[Segment 2]
HopField 0: ConsIngress: 0 ConsEgress: 500 ExpTime: 63 Xover: true VerifyOnly: false Mac: 59e7a8
HopField 1: ConsIngress: 2 ConsEgress: 0 ExpTime: 63 Xover: false VerifyOnly: false Mac: f01e93
Chosen path: Hops: [1-ff00:0:132 2>4078 1-ff00:0:131 4079>1001 1-ff00:0:130 1005>1 1-ff00:0:120 3>502 2-ff00:0:220 500>2 2-ff00:0:221] Mtu: 1400
DBUG[03-14|14:19:37] Registered with dispatcher               addr="1-ff00:0:132,[127.0.0.1]:1131 (UDP)"
Done. Wrote 11 bytes.
```

[metricapp]: https://github.com/chuyangliu/scion-apps/blob/3e8e8d5b26b9c0215588d055c1f2f3f35a3d6029/metricapp/main.go#L68
[query]: https://github.com/chuyangliu/scion-apps/blob/3e8e8d5b26b9c0215588d055c1f2f3f35a3d6029/metricapp/main.go#L57
[fwdpath]: https://github.com/chuyangliu/scion/blob/8a1c1b28145dd1b411645cad2d63a1e5a9a08617/go/lib/sciond/types.go#L193
[print-segments]: https://github.com/chuyangliu/scion/blob/8a1c1b28145dd1b411645cad2d63a1e5a9a08617/go/lib/sciond/types.go#L238
[build-reply]: https://github.com/chuyangliu/scion/blob/8a1c1b28145dd1b411645cad2d63a1e5a9a08617/go/sciond/internal/fetcher/fetcher.go#L287
[write-to]: https://github.com/chuyangliu/scion/blob/8a1c1b28145dd1b411645cad2d63a1e5a9a08617/go/lib/infra/modules/combinator/combinator.go#L116-L133